### PR TITLE
Don't add mruby's src to include paths

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,6 +1,4 @@
 MRuby::Gem::Specification.new('mruby-process') do |spec|
   spec.license = 'MIT'
   spec.authors = 'Internet Initiative Japan Inc.'
-
-  spec.cc.include_paths << "#{build.root}/src"
 end

--- a/src/process.c
+++ b/src/process.c
@@ -7,7 +7,7 @@
 #include "mruby/class.h"
 #include "mruby/string.h"
 #include "mruby/variable.h"
-#include "error.h"
+#include "mruby/error.h"
 
 #include <sys/types.h>
 #include <sys/time.h>


### PR DESCRIPTION
Since mruby/mruby#1720 this header file was moved to public include path of mruby, so we don't need to include the world anymore.

As of MRuby 1.1.0, this should work, but if you plan to support MRuby 1.0.0: we'll need to find a work-around.

You can see in mruby/mruby@e202d4cd530bfc660688da6316e33100b551ed83 a proxy header file was added for compatibility, maybe this helps.