### PR TITLE
Remove uninitialized block args

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -100,7 +100,7 @@ mrb_f_kill(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_f_fork(mrb_state *mrb, mrb_value klass)
 {
-  mrb_value b, result;
+  mrb_value b;
   int pid;
 
   mrb_get_args(mrb, "&", &b);
@@ -108,7 +108,7 @@ mrb_f_fork(mrb_state *mrb, mrb_value klass)
   switch (pid = fork()) {
   case 0:
     if (!mrb_nil_p(b)) {
-      mrb_yield(mrb, b, result);
+      mrb_yield_argv(mrb, b, 0, NULL);
       _exit(0);
     }
     return mrb_nil_value();


### PR DESCRIPTION
I found uninitialized value by `[-Wuninitialized]` warning.

```
CC    ../mruby-process/src/process.c -> build/host/mrbgems/mruby-process/src/process.o
/Users/yuki/src/github.com/ksss/mruby-process/src/process.c:111:25: warning: variable 'result' is uninitialized when used here
      [-Wuninitialized]
      mrb_yield(mrb, b, result);
                        ^~~~~~
/Users/yuki/src/github.com/ksss/mruby-process/src/process.c:103:3: note: variable 'result' is declared here
  mrb_value b, result;
  ^
1 warning generated.
```

`Process#fork` doesn't have a block argument in CRuby.
I fixed to remove block args for `Process#fork`.

### Code of reproduce.

```rb
pid = Process.fork { |i|
  p i
}
Process.waitpid(pid)
```

Actual

```sh
$mruby t.rb


$ 
```

Expect

```sh
$ mruby t.rb
nil

$
```