### PR TITLE
Update `$$` when fork is successful

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -112,6 +112,7 @@ mrb_f_fork(mrb_state *mrb, mrb_value klass)
 
   switch (pid = fork()) {
   case 0:
+    mrb_gv_set(mrb, mrb_intern_lit(mrb, "$$"), mrb_fixnum_value((mrb_int)getpid()));
     if (!mrb_nil_p(b)) {
       mrb_yield_argv(mrb, b, 0, NULL);
       _exit(0);


### PR DESCRIPTION
When `fork`'ed, the new process's `$$` value is unchanged from the parent one. This seems undesirable.

```ruby
> Process.waitpid(fork {p $$})
847 # <=!!!
 => 848
> p $$
847
 => 847
```

In CRuby:

```ruby
irb(main):002:0> Process.waitpid(fork {p $$})
459
=> 459
irb(main):003:0> p $$
449
=> 449
```

This patch fixes current behavior.